### PR TITLE
Adding the energy calculations to MJX

### DIFF
--- a/mjx/mujoco/mjx/_src/forward.py
+++ b/mjx/mujoco/mjx/_src/forward.py
@@ -403,12 +403,13 @@ def forward(m: Model, d: Data) -> Data:
   """Forward dynamics."""
   d = fwd_position(m, d)
   d = sensor.sensor_pos(m, d)
+  d = sensor.energy_pos(m, d)
   d = fwd_velocity(m, d)
   d = sensor.sensor_vel(m, d)
   d = fwd_actuation(m, d)
+  d = sensor.sensor_energy(m, d)
   d = fwd_acceleration(m, d)
   d = sensor.sensor_acc(m, d)
-
   if d.efc_J.size == 0:
     d = d.replace(qacc=d.qacc_smooth)
     return d

--- a/mjx/mujoco/mjx/_src/forward.py
+++ b/mjx/mujoco/mjx/_src/forward.py
@@ -407,7 +407,7 @@ def forward(m: Model, d: Data) -> Data:
   d = fwd_velocity(m, d)
   d = sensor.sensor_vel(m, d)
   d = fwd_actuation(m, d)
-  d = sensor.sensor_energy(m, d)
+  d = sensor.energy_vel(m, d)
   d = fwd_acceleration(m, d)
   d = sensor.sensor_acc(m, d)
   if d.efc_J.size == 0:

--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -363,6 +363,7 @@ def make_data(
         '_qM_sparse': (m.nM, float),
         '_qLD_sparse': (m.nM, float),
         '_qLDiagInv_sparse': (m.nv, float),
+        'energy': (2, float),
     }
 
     if not _full_compat:

--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -55,9 +55,9 @@ def _make_option(
     if o.solver not in set(types.SolverType):
       raise NotImplementedError(f'{mujoco.mjtSolver(o.solver)}')
 
-    for i in range(mujoco.mjtEnableBit.mjNENABLE):
-      if o.enableflags & 2**i:
-        raise NotImplementedError(f'{mujoco.mjtEnableBit(2 ** i)}')
+    # Check enable flags using enum pattern
+    if types.EnableBit(o.enableflags) not in set(types.EnableBit):
+      raise NotImplementedError(f'Unsupported enable flags: {mujoco.mjtEnableBit(o.enableflags)}')
 
   has_fluid_params = o.density > 0 or o.viscosity > 0 or o.wind.any()
   implicitfast = o.integrator == mujoco.mjtIntegrator.mjINT_IMPLICITFAST
@@ -71,6 +71,7 @@ def _make_option(
   fields['jacobian'] = types.JacobianType(o.jacobian)
   fields['solver'] = types.SolverType(o.solver)
   fields['disableflags'] = types.DisableBit(o.disableflags)
+  fields['enableflags'] = types.EnableBit(o.enableflags)
   fields['has_fluid_params'] = has_fluid_params
 
   return types.Option(**fields)

--- a/mjx/mujoco/mjx/_src/io.py
+++ b/mjx/mujoco/mjx/_src/io.py
@@ -56,8 +56,8 @@ def _make_option(
       raise NotImplementedError(f'{mujoco.mjtSolver(o.solver)}')
 
     # Check enable flags using enum pattern
-    if types.EnableBit(o.enableflags) not in set(types.EnableBit):
-      raise NotImplementedError(f'Unsupported enable flags: {mujoco.mjtEnableBit(o.enableflags)}')
+    if types.EnableBit(o.enableflags) not in set(types.EnableBit) and o.enableflags != 0:
+      raise NotImplementedError(f'{mujoco.mjtEnableBit(o.enableflags)}')
 
   has_fluid_params = o.density > 0 or o.viscosity > 0 or o.wind.any()
   implicitfast = o.integrator == mujoco.mjtIntegrator.mjINT_IMPLICITFAST

--- a/mjx/mujoco/mjx/_src/sensor.py
+++ b/mjx/mujoco/mjx/_src/sensor.py
@@ -27,6 +27,7 @@ from mujoco.mjx._src.types import DisableBit
 from mujoco.mjx._src.types import Model
 from mujoco.mjx._src.types import ObjType
 from mujoco.mjx._src.types import SensorType
+from mujoco.mjx._src.types import JointType
 # pylint: enable=g-importing-member
 import numpy as np
 
@@ -601,6 +602,67 @@ def sensor_acc(m: Model, d: Data) -> Data:
 
   return d.replace(sensordata=sensordata)
 
+
+def energy_pos(m: Model, d: Data) -> Data:
+    """Calculates position-dependent energy (potential).
+    """
+        
+    # Initialize potential energy
+    energy = jp.array(0.0)
+    
+    # Add gravitational potential energy for each body
+    if not m.opt.disableflags & DisableBit.GRAVITY:
+        for i in range(1, m.nbody):  # Skip world body
+            energy -= m.body_mass[i] * jp.dot(m.opt.gravity, d.xipos[i])
+    
+    # Add joint spring potential energy
+    if not m.opt.disableflags & DisableBit.PASSIVE:
+        for i in range(m.njnt):
+            stiffness = m.jnt_stiffness[i]
+            padr = m.jnt_qposadr[i]
+            
+            if m.jnt_type[i] == JointType.FREE:
+                # Position springs
+                quat = d.qpos[padr:padr+4]
+                quat = math.normalize(quat)
+                dif = quat - m.qpos_spring[padr:padr+4]
+                energy += 0.5 * stiffness * jp.dot(dif[:3], dif[:3])
+                
+                # Handle rotations
+                padr += 3
+                
+            if m.jnt_type[i] in (JointType.FREE, JointType.BALL):
+                # Convert quaternion difference to angular displacement
+                quat = d.qpos[padr:padr+4]
+                quat = math.normalize(quat)
+                dif = math.quat_sub(quat, m.qpos_spring[padr:padr+4])
+                energy += 0.5 * stiffness * jp.dot(dif, dif)
+                
+            elif m.jnt_type[i] in (JointType.SLIDE, JointType.HINGE):
+                dif = d.qpos[padr] - m.qpos_spring[padr]
+                energy += 0.5 * stiffness * dif * dif
+
+    # Add tendon spring potential energy
+    if not m.opt.disableflags & DisableBit.PASSIVE:
+        for i in range(m.ntendon):
+            stiffness = m.tendon_stiffness[i]
+            length = d.ten_length[i]
+            
+            # Compute spring displacement
+            lower = m.tendon_lengthspring[2*i]
+            upper = m.tendon_lengthspring[2*i+1]
+            
+            if length > upper:
+                displacement = upper - length
+            elif length < lower:
+                displacement = lower - length
+            else:
+                displacement = 0.0
+                
+            energy += 0.5 * stiffness * displacement * displacement
+
+    # Update energy[0] (potential energy) in data
+    return d.replace(energy=d.energy.at[0].set(energy))
 
 
 def energy_vel(m: Model, d: Data) -> Data:

--- a/mjx/mujoco/mjx/_src/sensor.py
+++ b/mjx/mujoco/mjx/_src/sensor.py
@@ -600,3 +600,14 @@ def sensor_acc(m: Model, d: Data) -> Data:
   )
 
   return d.replace(sensordata=sensordata)
+
+
+
+def energy_vel(m: Model, d: Data) -> Data:
+    """Calculates velocity-dependent energy (kinetic).
+    """
+
+    vec = support.mul_m(m, d, d.qvel)
+    energy = 0.5 * jp.dot(vec, d.qvel)
+    
+    return d.replace(energy=d.energy.at[1].set(energy))

--- a/mjx/mujoco/mjx/_src/sensor.py
+++ b/mjx/mujoco/mjx/_src/sensor.py
@@ -28,6 +28,7 @@ from mujoco.mjx._src.types import Model
 from mujoco.mjx._src.types import ObjType
 from mujoco.mjx._src.types import SensorType
 from mujoco.mjx._src.types import JointType
+from mujoco.mjx._src.types import EnableBit
 # pylint: enable=g-importing-member
 import numpy as np
 
@@ -609,6 +610,8 @@ def energy_pos(m: Model, d: Data) -> Data:
         
     # Initialize potential energy
     energy = jp.array(0.0)
+    if not m.opt.enableflags & EnableBit.ENERGY:
+        return d
     
     # Add gravitational potential energy for each body
     if not m.opt.disableflags & DisableBit.GRAVITY:
@@ -668,6 +671,8 @@ def energy_pos(m: Model, d: Data) -> Data:
 def energy_vel(m: Model, d: Data) -> Data:
     """Calculates velocity-dependent energy (kinetic).
     """
+    if not m.opt.enableflags & EnableBit.ENERGY:
+        return d
 
     vec = support.mul_m(m, d, d.qvel)
     energy = 0.5 * jp.dot(vec, d.qvel)

--- a/mjx/mujoco/mjx/_src/sensor_test.py
+++ b/mjx/mujoco/mjx/_src/sensor_test.py
@@ -71,12 +71,7 @@ class SensorTest(parameterized.TestCase):
         cacc=jp.zeros_like(d.cacc),
         cfrc_int=jp.zeros_like(d.cfrc_int),
         cfrc_ext=jp.zeros_like(d.cfrc_ext),
-        energy=jp.zeros_like(d.energy),  # Reset energy
     )
-    
-    # Calculate energies
-    dx = jax.jit(mjx.energy_pos)(mx, dx)
-    dx = jax.jit(mjx.energy_vel)(mx, dx)
     
     # Test sensor functions
     dx = jax.jit(mjx.sensor_pos)(mx, dx)
@@ -84,10 +79,6 @@ class SensorTest(parameterized.TestCase):
     dx = jax.jit(mjx.sensor_acc)(mx, dx)
 
     _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
-    
-    # Test potential and kinetic energies match
-    _assert_eq(d.energy[0], dx.energy[0], 'potential energy')
-    _assert_eq(d.energy[1], dx.energy[1], 'kinetic energy')
 
   def test_disable_sensor(self):
     """Tests disabling sensor."""
@@ -129,6 +120,51 @@ class SensorTest(parameterized.TestCase):
     """)
     with self.assertRaises(NotImplementedError):
       mjx.put_model(m)
+
+  def test_energy(self):
+    """Tests energy calculations with and without enable flag."""
+    m = test_util.load_test_file('sensor/sensor.xml')
+    d = mujoco.MjData(m)
+    
+    # Set up non-zero state
+    d.qvel = 0.1 * np.random.random(m.nv)
+    d.qpos = m.qpos0 + 0.1 * np.random.random(m.nq)
+    mujoco.mj_step(m, d, 10)
+    mujoco.mj_forward(m, d)
+
+    # JIT compile energy functions once
+    energy_pos_fn = jax.jit(mjx.energy_pos)
+    energy_vel_fn = jax.jit(mjx.energy_vel)
+
+    # Test without enabling energy flag
+    mx = mjx.put_model(m)
+    dx = mjx.put_data(m, d).replace(energy=jp.zeros_like(d.energy))
+    
+    # Calculate energies without flag - should be zero
+    dx = energy_pos_fn(mx, dx)
+    dx = energy_vel_fn(mx, dx)
+
+    # Verify energies are zero without enable flag
+    np.testing.assert_array_equal(dx.energy, jp.zeros_like(dx.energy))
+
+    # Now enable energy calculations in both MuJoCo and MJX
+    m.opt.enableflags |= mujoco.mjtEnableBit.mjENBL_ENERGY
+    mujoco.mj_forward(m, d)  # Recalculate MuJoCo energies with flag enabled
+    
+    mx = mjx.put_model(m)
+    dx = mjx.put_data(m, d).replace(energy=jp.zeros_like(d.energy))
+    
+    # Calculate energies with flag enabled
+    dx = energy_pos_fn(mx, dx)
+    dx = energy_vel_fn(mx, dx)
+
+    # Verify energies match MuJoCo with enable flag
+    _assert_eq(d.energy[0], dx.energy[0], 'potential energy')
+    _assert_eq(d.energy[1], dx.energy[1], 'kinetic energy')
+
+    # Verify energy values are non-zero
+    self.assertGreater(abs(dx.energy[0]) + abs(dx.energy[1]), 0,
+                      'Expected non-zero energy values')
 
 
 if __name__ == '__main__':

--- a/mjx/mujoco/mjx/_src/sensor_test.py
+++ b/mjx/mujoco/mjx/_src/sensor_test.py
@@ -71,12 +71,23 @@ class SensorTest(parameterized.TestCase):
         cacc=jp.zeros_like(d.cacc),
         cfrc_int=jp.zeros_like(d.cfrc_int),
         cfrc_ext=jp.zeros_like(d.cfrc_ext),
+        energy=jp.zeros_like(d.energy),  # Reset energy
     )
+    
+    # Calculate energies
+    dx = jax.jit(mjx.energy_pos)(mx, dx)
+    dx = jax.jit(mjx.energy_vel)(mx, dx)
+    
+    # Test sensor functions
     dx = jax.jit(mjx.sensor_pos)(mx, dx)
     dx = jax.jit(mjx.sensor_vel)(mx, dx)
     dx = jax.jit(mjx.sensor_acc)(mx, dx)
 
     _assert_eq(d.sensordata, dx.sensordata, 'sensordata')
+    
+    # Test potential and kinetic energies match
+    _assert_eq(d.energy[0], dx.energy[0], 'potential energy')
+    _assert_eq(d.energy[1], dx.energy[1], 'kinetic energy')
 
   def test_disable_sensor(self):
     """Tests disabling sensor."""

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -1330,6 +1330,7 @@ class Data(PyTreeNode):
     _qM_sparse: qM in sparse representation                     (nM,)
     _qLD_sparse: qLD in sparse representation                   (nM,)
     _qLDiagInv_sparse: qLDiagInv in sparse representation       (nv,)
+    energy: potential, kinetic energy (2, )
   """  # fmt: skip
   # constant sizes:
   ne: int
@@ -1467,3 +1468,4 @@ class Data(PyTreeNode):
   _qM_sparse: jax.Array = _restricted_to('mjx')  # pylint:disable=invalid-name
   _qLD_sparse: jax.Array = _restricted_to('mjx')  # pylint:disable=invalid-name
   _qLDiagInv_sparse: jax.Array = _restricted_to('mjx')  # pylint:disable=invalid-name
+  energy: jax.Array

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -491,7 +491,7 @@ class Option(PyTreeNode):
   noslip_iterations: int = _restricted_to('mujoco')
   ccd_iterations: int = _restricted_to('mujoco')
   disableflags: DisableBit
-  enableflags: int
+  enableflags: EnableBit
   disableactuator: int
   sdf_initpoints: int = _restricted_to('mujoco')
   sdf_iterations: int = _restricted_to('mujoco')

--- a/mjx/mujoco/mjx/_src/types.py
+++ b/mjx/mujoco/mjx/_src/types.py
@@ -65,6 +65,15 @@ class DisableBit(enum.IntFlag):
   # unsupported: MIDPHASE
 
 
+class EnableBit(enum.IntFlag):
+  """Enable optional feature bitflags.
+
+  Members:
+    ENERGY: enable energy computation
+  """
+
+  ENERGY = mujoco.mjtEnableBit.mjENBL_ENERGY
+
 class JointType(enum.IntEnum):
   """Type of degree of freedom.
 

--- a/mjx/pyproject.toml
+++ b/mjx/pyproject.toml
@@ -30,9 +30,6 @@ dependencies = [
     "etils[epath]",
     "jax",
     "jaxlib",
-    "mujoco>=3.2.7.dev0",
-    "scipy",
-    "trimesh",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Add energy calculations to MJX

This PR adds support for kinetic and potential energy calculations in MJX, matching MuJoCo's implementation. Key changes:

- Add energy_pos() and energy_vel() functions to sensor.py for calculating potential and kinetic energy respectively
- Add EnableBit.ENERGY flag support to control energy calculations